### PR TITLE
fixes for oki weapons

### DIFF
--- a/Data/MWI/CubeBlocks.sbc
+++ b/Data/MWI/CubeBlocks.sbc
@@ -262,7 +262,7 @@
       <MirroringZ>Y</MirroringZ>
       <BuildTimeSeconds>15</BuildTimeSeconds>
       <EdgeType>Light</EdgeType>
-      <WeaponDefinitionId Subtype="OKI76mmASG" />
+      <WeaponDefinitionId Subtype="OKI122mmAGfixed" />
       <InventoryMaxVolume>0.300</InventoryMaxVolume>
       <DamageEffectId>213</DamageEffectId>
       <DeformationRatio>0</DeformationRatio>
@@ -554,7 +554,7 @@
       <EdgeType>Heavy</EdgeType>
       <BuildTimeSeconds>25</BuildTimeSeconds>
       <OverlayTexture>Textures\GUI\Screens\turret_overlay.dds</OverlayTexture>      
-      <WeaponDefinitionId Subtype="OKI76mmASG" />
+      <WeaponDefinitionId Subtype="OKI122mmVT" />
       <InventoryMaxVolume>0.720</InventoryMaxVolume>
       <DamageEffectId>213</DamageEffectId>
       <MinElevationDegrees>-15</MinElevationDegrees> 

--- a/Data/MWI/CubeBlocks.sbc
+++ b/Data/MWI/CubeBlocks.sbc
@@ -225,7 +225,7 @@
       <Id>
         <TypeId>SmallGatlingGun</TypeId>
         <SubtypeId>OKI122mmAGfixed</SubtypeId>
-	</Id>
+	    </Id>
       <DisplayName>OKI 122mm Fixed Assault Cannon</DisplayName>
       <Icon>icons\OKI122mmASG_fixed.dds</Icon>
       <Description>Bulky fixed weapon for small vessels. Powerful at close range, but useless above 600 meters. Deals heavy damage to light armor and moderate damage to heavy armor.</Description>
@@ -503,7 +503,7 @@
       <RotationSpeed>0.001</RotationSpeed>
       <ElevationSpeed>0.001</ElevationSpeed>
       <IdleRotation>false</IdleRotation>
-      <MaxRangeMeters>800</MaxRangeMeters>
+      <MaxRangeMeters>1800</MaxRangeMeters>
       <AiEnabled>true</AiEnabled>
       <DeformationRatio>0</DeformationRatio>
       <GeneralDamageMultiplier>0.8</GeneralDamageMultiplier>
@@ -564,11 +564,11 @@
       <RotationSpeed>0.001</RotationSpeed>
       <ElevationSpeed>0.001</ElevationSpeed>
       <IdleRotation>false</IdleRotation>
-      <MaxRangeMeters>1800</MaxRangeMeters>
+      <MaxRangeMeters>2200</MaxRangeMeters>
       <AiEnabled>true</AiEnabled>
       <DeformationRatio>0</DeformationRatio>
       <GeneralDamageMultiplier>0.8</GeneralDamageMultiplier>
-      <PCU>620</PCU>
+      <PCU>613</PCU>
     </Definition> 
 
 <Definition xsi:type="MyObjectBuilder_LargeTurretBaseDefinition">

--- a/Data/MWI/CubeBlocks.sbc
+++ b/Data/MWI/CubeBlocks.sbc
@@ -271,7 +271,7 @@
 
 <!-- =====================================small grid turrets============================================ -->
 
-<Definition xsi:type="MyObjilder_LargeTurretBaseDefinition">
+<Definition xsi:type="MyObjectBuilder_LargeTurretBaseDefinition">
       <Id>
         <TypeId>LargeGatlingTurret</TypeId>
         <SubtypeId>OKI23mmSG</SubtypeId>

--- a/Data/MWI/Weapons.sbc
+++ b/Data/MWI/Weapons.sbc
@@ -15,7 +15,7 @@
       <AmmoMagazines>
         <AmmoMagazine Subtype="OKIObserverMAG" />
       </AmmoMagazines>    
-      <ReloadTime>6</ReloadTime>      
+      <ReloadTime>6000</ReloadTime>      
     </Weapon>
 
     <Weapon>
@@ -39,16 +39,17 @@
         <TypeId>WeaponDefinition</TypeId>
         <SubtypeId>OKI23mmDG</SubtypeId>
       </Id>
-      <ProjectileAmmoData RateOfFire="900" ShootSoundName="OKI23mmshot" ShotsInBurst="120" />
+      <ProjectileAmmoData RateOfFire="600" ShootSoundName="OKI23mmshot" ShotsInBurst="60" />
       <NoAmmoSoundName>WepPlayRifleNoAmmo</NoAmmoSoundName>
-      <DeviateShotAngle>1.5</DeviateShotAngle>
+      <DeviateShotAngle>3</DeviateShotAngle>
       <ReleaseTimeAfterFire>40</ReleaseTimeAfterFire>
       <MuzzleFlashLifeSpan>1</MuzzleFlashLifeSpan>
       <AmmoMagazines>
         <AmmoMagazine Subtype="OKI23mmAmmo" />
       </AmmoMagazines>      
-      <ReloadTime>2000</ReloadTime>
+      <ReloadTime>5000</ReloadTime>
     </Weapon>
+
     <Weapon>
       <Id>
         <TypeId>WeaponDefinition</TypeId>
@@ -72,7 +73,7 @@
       </Id>
       <MissileAmmoData RateOfFire="100" ShootSoundName="OKI50mmshot" ShotsInBurst="24" /> 
       <NoAmmoSoundName>WepPlayRifleNoAmmo</NoAmmoSoundName>
-      <DeviateShotAngle>0.1</DeviateShotAngle>
+      <DeviateShotAngle>0.2</DeviateShotAngle>
       <ReleaseTimeAfterFire>240</ReleaseTimeAfterFire>
       <MuzzleFlashLifeSpan>1</MuzzleFlashLifeSpan> 
       <UseDefaultMuzzleFlash>false</UseDefaultMuzzleFlash>
@@ -82,7 +83,7 @@
       <AmmoMagazines>
         <AmmoMagazine Subtype="OKI50mmAmmo" />
       </AmmoMagazines>
-      <ReloadTime>4400</ReloadTime>
+      <ReloadTime>4000</ReloadTime>
     </Weapon>
 
     <Weapon>
@@ -166,7 +167,7 @@
       <AmmoMagazines>
         <AmmoMagazine Subtype="OKI122mmAmmo" />
       </AmmoMagazines>
-      <ReloadTime>5200</ReloadTime>
+      <ReloadTime>4000</ReloadTime>
     </Weapon>
 
     <Weapon>
@@ -187,7 +188,7 @@
       <AmmoMagazines>
         <AmmoMagazine Subtype="OKI230mmAmmo" />
       </AmmoMagazines>
-      <ReloadTime>5000</ReloadTime>
+      <ReloadTime>1110</ReloadTime>
     </Weapon> 
 
     <Weapon>

--- a/Data/MWI/Weapons.sbc
+++ b/Data/MWI/Weapons.sbc
@@ -212,5 +212,49 @@
       <ReloadTime>1910</ReloadTime>
     </Weapon>
 
+<!--  New subtypes added for small grid assault guns   -->
+
+    <Weapon>
+      <Id>
+        <TypeId>WeaponDefinition</TypeId>
+        <SubtypeId>OKI122mmAGfixed</SubtypeId>
+      </Id>
+      <MissileAmmoData RateOfFire="30" ShootSoundName="OKI76mmshot" ShotsInBurst="1"/>
+      <ShotSoundName>OKI76mmshot</ShotSoundName>
+      <NoAmmoSoundName>WepPlayRifleNoAmmo</NoAmmoSoundName>
+      <DeviateShotAngle>0.2</DeviateShotAngle>
+      <ReleaseTimeAfterFire>1000</ReleaseTimeAfterFire>
+      <MuzzleFlashLifeSpan>1</MuzzleFlashLifeSpan>
+      <UseDefaultMuzzleFlash>false</UseDefaultMuzzleFlash>
+      <Effects>
+        <Effect Action="Shoot" Dummy="muzzle_projectile001" Particle="OKI_122mm_Muzzle_Flash" Loop="false" InstantStop="true"/>
+      </Effects>
+      <AmmoMagazines>
+        <AmmoMagazine Subtype="OKI122mmAmmo" />
+      </AmmoMagazines>
+      <ReloadTime>5200</ReloadTime>
+    </Weapon>
+
+    <Weapon>
+      <Id>
+        <TypeId>WeaponDefinition</TypeId>
+        <SubtypeId>OKI122mmVT</SubtypeId>
+      </Id>
+      <MissileAmmoData RateOfFire="30" ShootSoundName="OKI76mmshot" ShotsInBurst="1"/>
+      <ShotSoundName>OKI76mmshot</ShotSoundName>
+      <NoAmmoSoundName>WepPlayRifleNoAmmo</NoAmmoSoundName>
+      <DeviateShotAngle>0.2</DeviateShotAngle>
+      <ReleaseTimeAfterFire>1000</ReleaseTimeAfterFire>
+      <MuzzleFlashLifeSpan>1</MuzzleFlashLifeSpan>
+      <UseDefaultMuzzleFlash>false</UseDefaultMuzzleFlash>
+      <Effects>
+        <Effect Action="Shoot" Dummy="muzzle_projectile001" Particle="OKI_122mm_Muzzle_Flash" Loop="false" InstantStop="true"/>
+      </Effects>
+      <AmmoMagazines>
+        <AmmoMagazine Subtype="OKI122mmAmmo" />
+      </AmmoMagazines>
+      <ReloadTime>1700</ReloadTime>
+    </Weapon>
+
   </Weapons>
 </Definitions>


### PR DESCRIPTION
weapons.sbc:
OKI230mmBC - fixed reload time
OKI50mmAG - fixed reload & shot deviation
OKI23mmDG - fixed RoF, shot deviation, reload
OKIObserverWEP - fixed reload time

cubeblocks.sbc:
OKI122mmVT - fixed pcu and max range
OKI50mmVT - fixed range